### PR TITLE
Update upstream references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.7
 
+ENV LANG=C.UTF-8
+
 # Here we install GNU libc (aka glibc) and set C.UTF-8 locale as default.
 
 RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
@@ -21,8 +23,8 @@ RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases
         "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
     \
     rm "/etc/apk/keys/sgerrand.rsa.pub" && \
-    /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true && \
-    echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
+    /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true && \
+    echo "export LANG=$LANG" > /etc/profile.d/locale.sh && \
     \
     apk del glibc-i18n && \
     \
@@ -32,5 +34,3 @@ RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases
         "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
         "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
         "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME"
-
-ENV LANG=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases
     ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
     apk add --no-cache --virtual=.build-dependencies wget ca-certificates && \
     wget \
-        "https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/sgerrand.rsa.pub" \
+        "https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub" \
         -O "/etc/apk/keys/sgerrand.rsa.pub" && \
     wget \
         "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This image is based on Alpine Linux image, which is only a 5MB image, and contai
 proprietary projects compiled against glibc (e.g. OracleJDK, Anaconda) work on Alpine.
 
 This image includes some quirks to make [glibc](https://www.gnu.org/software/libc/) work side by
-side with musl libc (default in Apline Linux). glibc packages for Alpine Linux are prepared by
+side with musl libc (default in Alpine Linux). glibc packages for Alpine Linux are prepared by
 [Andy Shinn](https://github.com/andyshinn) and the releases are published in
 [andyshinn/alpine-pkg-glibc](https://github.com/andyshinn/alpine-pkg-glibc) github repo.
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ proprietary projects compiled against glibc (e.g. OracleJDK, Anaconda) work on A
 
 This image includes some quirks to make [glibc](https://www.gnu.org/software/libc/) work side by
 side with musl libc (default in Alpine Linux). glibc packages for Alpine Linux are prepared by
-[Andy Shinn](https://github.com/andyshinn) and the releases are published in
-[andyshinn/alpine-pkg-glibc](https://github.com/andyshinn/alpine-pkg-glibc) github repo.
+[Sasha Gerrand](https://github.com/sgerrand) and the releases are published in
+[sgerrand/alpine-pkg-glibc](https://github.com/sgerrand/alpine-pkg-glibc) github repo.
 
 Download size of this image is only:
 


### PR DESCRIPTION
💁 These changes update the references to the upstream maintainer of [`alpine-pkg-glibc`](https://github.com/sgerrand/alpine-pkg-glibc).